### PR TITLE
adding network_model path to config file

### DIFF
--- a/etc/access_policy.xml
+++ b/etc/access_policy.xml
@@ -1,4 +1,6 @@
 <accessPolicy>
+  <rabbit host="localhost" port="5672" user="guest" pass="guest"/>
+  <network_model path="/var/run/vce/network_model.json"/>
 
   <switch name="foobar"  ip="managementip" username="username" password="password" description="Foo">
 

--- a/lib/VCE.pm
+++ b/lib/VCE.pm
@@ -134,6 +134,10 @@ sub _process_config{
     my %workgroups;
     my %users;
 
+    if (defined $config->get('/accessPolicy/network_model')->[0]) {
+        $self->_set_network_model_file($config->get('/accessPolicy/network_model')->[0]->{'path'});
+    }
+
     my $rabbitMQ = $config->get('/accessPolicy/rabbit')->[0];
     $self->logger->error("RabbitMQ: " . Data::Dumper::Dumper($rabbitMQ));
     $self->_set_rabbit_mq($rabbitMQ);

--- a/vce.spec
+++ b/vce.spec
@@ -26,7 +26,6 @@ Requires: perl-GRNOC-WebService-Client
 Requires: perl-Moo
 Requires: perl-Parallel-ForkManager
 Requires: perl-Test-Deep
-Requires: perl-Type-Tiny
 
 
 %description


### PR DESCRIPTION
Permissions get annoying when doing tests that involve clearing the network_model. Adding a network_model path to the config lets us load network_models with less restrictive permissions.