### PR TITLE
Parsing vlan string into array and hiding hidden vlan_id

### DIFF
--- a/www/frontend/assets/js/create.js
+++ b/www/frontend/assets/js/create.js
@@ -23,10 +23,13 @@ function loadVlanDropdown() {
             endpoints_z.innerHTML = '';
             
             // Loads valid VLANS
-            for (var i = 0; i < ports[0].tags.length; i++) {
+            var parts = ports[0].tags[0].split("-");
+            var low = parts[0];
+            var high = parts[1];
+            for (var i = low; i <= high; i++) {
                 var opt = document.createElement('option');
-                opt.innerHTML = ports[0].tags[i];
-                opt.setAttribute('value', ports[0].tags[i]);
+                opt.innerHTML = i;
+                opt.setAttribute('value', i);
                 dropd.appendChild(opt);
             }
             

--- a/www/frontend/assets/js/form.js
+++ b/www/frontend/assets/js/form.js
@@ -10,6 +10,7 @@
  * - workgroup
  * - switch
  * - port
+ * - vlan_id
  *
  * After submit, the results of a successful request will be
  * added to a pre tag, and placed in #result_text.
@@ -53,7 +54,7 @@ function NewCommandForm(details, reponseFunc) {
         label.innerHTML = param.name;
         
         // Create hidden forms for data stored in cookie
-        if (param.name == "workgroup" || param.name == "switch" || param.name == "port") {
+        if (param.name == "workgroup" || param.name == "switch" || param.name == "port" || param.name == "vlan_id") {
             group.style.display = "none";
         }
 
@@ -94,6 +95,8 @@ function NewCommandForm(details, reponseFunc) {
                 value = cookie.switch;
             } else if (name == "port") {
                 value = cookie.port;
+            } else if (name == "vlan_id") {
+                value = cookie.selectedVlanId;
             }
             
             url += "&" + name + "=" + value;


### PR DESCRIPTION
Without parsing the vlan string into an array choosing a unique vlan
from the drop down is impossible. Vlan id is a required field as is
set by the session so should not be displayed to user.