### PR TITLE
Adding ability to delete vlans from device configuration

### DIFF
--- a/lib/VCE/Services/Provisioning.pm
+++ b/lib/VCE/Services/Provisioning.pm
@@ -365,6 +365,8 @@ sub delete_vlan{
         }
     }
 
+    $self->_send_no_vlan($switch, $vlan);
+
     $self->vce->network_model->delete_vlan( vlan_id => $vlan_id);
     return {results => [{success => 1}]};
 }
@@ -409,6 +411,21 @@ sub _send_vlan_remove{
     $self->logger->info("Removing vlan $vlan from port $port on $switch");
 
     my $response = $self->switch->no_interface_tagged(port => $port, vlan => $vlan);
+    if (exists $response->{'results'}->{'error'}) {
+        $self->logger->error($response->{'results'}->{'error'});
+        return 0;
+    }
+
+    return 1;
+}
+
+sub _send_no_vlan {
+    my $self   = shift;
+    my $switch = shift;
+    my $vlan   = shift;
+    $self->logger->info("Removing vlan $vlan from $switch");
+
+    my $response = $self->switch->no_vlan(vlan => $vlan);
     if (exists $response->{'results'}->{'error'}) {
         $self->logger->error($response->{'results'}->{'error'});
         return 0;

--- a/lib/VCE/Switch.pm
+++ b/lib/VCE/Switch.pm
@@ -231,6 +231,15 @@ sub _register_rpc_methods{
 				  pattern     => $GRNOC::WebService::Regex::INTEGER );
     $d->register_method($method);
 
+    $method = GRNOC::RabbitMQ::Method->new( name => "no_vlan",
+                                            callback => sub { return $self->no_vlan(@_) },
+                                            description => "Sets a vlan's description" );
+    $method->add_input_parameter( name        => "vlan",
+				  description => "VLAN number to use for tag",
+				  required    => 1,
+				  pattern     => $GRNOC::WebService::Regex::INTEGER );
+    $d->register_method($method);
+
     $method = GRNOC::RabbitMQ::Method->new( name => "interface_tagged",
                                             callback => sub { return $self->interface_tagged( @_ )  },
                                             description => "Add vlan tagged interface" );
@@ -361,6 +370,30 @@ sub no_interface_tagged {
     }
 
     my ($res, $err) = $self->device->no_interface_tagged($port, $vlan);
+    if (defined $err) {
+        $self->logger->error($err);
+        return { results => undef, error => $err };
+    }
+
+    return { results => 1 };
+}
+
+=head2 no_vlan
+
+=cut
+
+sub no_vlan {
+    my $self   = shift;
+    my $method = shift;
+    my $params = shift;
+
+    my $vlan = $params->{'vlan'}{'value'};
+
+    if (!$self->device->connected) {
+        $self->logger->error("Error device is not connected.");
+    }
+
+    my ($res, $err) = $self->device->no_vlan($vlan);
     if (defined $err) {
         $self->logger->error($err);
         return { results => undef, error => $err };


### PR DESCRIPTION
In the device configuration, a vlan is added when tagging an interface
pair. When untagging the pair however, the vlan was not being not
removed. This caused unused blocks to remain in the device
configuration. After untagging the port pair, we now delete this extra
bit of configuration.