### PR TITLE
Cleaning up startup

### DIFF
--- a/lib/VCE.pm
+++ b/lib/VCE.pm
@@ -171,7 +171,7 @@ sub _process_config{
     my %switches;
     my $switches = $config->get('/accessPolicy/switch');
     foreach my $switch (@$switches){
-	$self->logger->debug("Processing switch: " . Data::Dumper::Dumper($switch));
+	$self->logger->debug("Processing config for $switch->{'name'}");
 	my $s = {};
 	$s->{'name'} = $switch->{'name'};
 	$s->{'description'} = $switch->{'description'};

--- a/lib/VCE/NetworkModel.pm
+++ b/lib/VCE/NetworkModel.pm
@@ -60,7 +60,6 @@ sub _read_network_model{
     my $self = shift;
 
     if(!-e $self->file ){
-	
         $self->_set_nm({vlans => {}});
         $self->_write_network_model();
 
@@ -70,8 +69,14 @@ sub _read_network_model{
         while(my $line = <$fh>){
             $str .= $line;
         }
+
         my $data = decode_json($str);
-        $self->_set_nm($data);
+        if (!%{$data}) {
+            $self->_set_nm({vlans => {}});
+            $self->_write_network_model();
+        } else {
+            $self->_set_nm($data);
+        }
     }
 }
 


### PR DESCRIPTION
When loading the configuration we had been dumping the entire switch
configuration to the log; This was not secure as it included
passwords.

We now add the vlans key to the network model when loading an empty
json object; This is just to make the expected data model more
explicit.