### PR TITLE
Replacing _process_interfaces with get_interfaces_state

### DIFF
--- a/lib/VCE/NetworkModel.pm
+++ b/lib/VCE/NetworkModel.pm
@@ -62,7 +62,6 @@ sub _read_network_model{
     if(!-e $self->file ){
         $self->_set_nm({vlans => {}});
         $self->_write_network_model();
-
     }else{
         my $str;
         open(my $fh, "<", $self->file);

--- a/lib/VCE/Services/Operational.pm
+++ b/lib/VCE/Services/Operational.pm
@@ -163,7 +163,6 @@ sub get_interfaces_operational_status {
         foreach my $port (@{$ports}) {
             my $pdata = $port_info->{'results'}->{$port->{'port'}};
             $pdata->{'tags'} = $self->vce->access->friendly_display_vlans($port->{'tags'});
-            $pdata->{'description'} = $self->vce->config->{'switches'}->{$switch}->{'ports'}->{$port->{'port'}}->{'description'};
             push(@{$result}, $pdata);
         }
 


### PR DESCRIPTION
The way were parsed output from `show interfaces brief` was broken. If
the port name had spaces, only the first word was recorded. In
addition, the second word was recorded as the type.

Using NETCONF and GET interface-statedata, we're getting the same data
minus trunk and type. Spaces in port names are no longer an issue, and
the port ID is now reported in full (ethernet 15/2 vs 15/2).