### PR TITLE
Performance improvement and more vlan name translations

### DIFF
--- a/lib/VCE.pm
+++ b/lib/VCE.pm
@@ -486,19 +486,19 @@ sub _get_interface_status{
     my $self = shift;
     my %params = @_;
 
-    my $state = $self->device_client->get_interface_status( interface => $params{'interface'})->{'results'};
-    $self->logger->error("Interface Status: " . Data::Dumper::Dumper($state));
-    if(!defined($state)){
+    my $state = $self->device_client->get_interface_status(interface => $params{'interface'})->{'results'};
+    if (!defined $state || defined $state->{'error'}) {
+        $self->logger->error("Interface Status: " . Data::Dumper::Dumper($state));
         return "Unknown";
     }
-    if($state->{'status'} == 1){
+
+    if ($state->{'status'} == 1) {
         return 'Up';
-    }elsif($state->{'status'} == 0){
+    } elsif ($state->{'status'} == 0) {
         return 'Down';
-    }else{
+    } else {
         return 'Unknown';
     }
-
 }
 
 =head2 is_tag_available

--- a/lib/VCE/Access.pm
+++ b/lib/VCE/Access.pm
@@ -272,31 +272,39 @@ sub get_tags_on_port{
     my %params = @_;
 
     if(!defined($params{'workgroup'})){
-        $self->logger->error("get_available_tags_on_port: workgroup not specified");
+        $self->logger->error("get_tags_on_port: workgroup not specified");
         return;
     }
 
     if(!defined($params{'switch'})){
-        $self->logger->error("get_available_tags_on_port: switch not specified");
+        $self->logger->error("get_tags_on_port: switch not specified");
         return;
     }
 
     if(!defined($params{'port'})){
-        $self->logger->error("get_available_tags_on_port: port not specified");
+        $self->logger->error("get_tags_on_port: port not specified");
         return;
     }
-    
-    my @available_tags;
-    for(my $vlan = 1; $vlan < 4095; $vlan++){
-        if($self->workgroup_has_access_to_port( workgroup => $params{'workgroup'},
-                                                switch => $params{'switch'},
-                                                port => $params{'port'},
-                                                vlan => $vlan)){
-            push(@available_tags, $vlan);
+
+    if (!defined $self->config->{'switches'}->{$params{'switch'}}) {
+        return [];
+    }
+    my $switch = $self->config->{'switches'}->{$params{'switch'}};
+
+    if (!defined $switch->{'ports'}->{$params{'port'}}) {
+        return [];
+    }
+    my $port = $switch->{'ports'}->{$params{'port'}};
+
+    my $available_tags;
+
+    foreach my $vlan (keys %{$port->{'tags'}}) {
+        if ($port->{'tags'}->{$vlan} eq $params{'workgroup'}) {
+            push(@{$available_tags}, $vlan);
         }
     }
-    return \@available_tags;
-    
+
+    return $available_tags;
 }
 
 

--- a/lib/VCE/Access.pm
+++ b/lib/VCE/Access.pm
@@ -310,8 +310,11 @@ sub get_tags_on_port{
 
 =head2 friendly_display_vlans
 
-=cut
+friendly_display_vlans takes an arrary of vlans and returns a list of
+human readable vlan ranges. An example range looks like `100-200`, and
+will always be of form `low-high`.
 
+=cut
 sub friendly_display_vlans{
     my $self = shift;
     my $vlans = shift;
@@ -320,7 +323,10 @@ sub friendly_display_vlans{
     my $first;
     my $last;
 
-    foreach my $vlan (@$vlans){
+    # The work below expects a sorted array of vlans
+    my @sorted_vlans = sort { $a <=> $b } @{$vlans};
+
+    foreach my $vlan (@sorted_vlans) {
         if(!defined($first)){
             $first = $vlan;
             $last = $vlan;
@@ -343,11 +349,10 @@ sub friendly_display_vlans{
 
     #do the last push
     if($first == $last){
-	push(@f_vlans, $first);
+        push(@f_vlans, $first);
     }else{
-	push(@f_vlans, $first . "-" . $last);
+        push(@f_vlans, $first . "-" . $last);
     }
-
     return \@f_vlans;
 }
 

--- a/lib/VCE/Device/Brocade/MLXe/5_8_0.pm
+++ b/lib/VCE/Device/Brocade/MLXe/5_8_0.pm
@@ -402,7 +402,6 @@ sub _get_interface{
     my $int = {};
     foreach my $line (split(/\n/,$int_details)){
 	if($line =~ /^\s/){
-	    
 	    if($line =~ /Hardware is (\S+), address is (\S+)/){
 		$int->{'hardware_type'} = $1;
 		$int->{'mac_addr'} = $2;
@@ -415,7 +414,7 @@ sub _get_interface{
 	    if($line =~ /MTU (\d+)/){
 		$int->{'mtu'} = $1;
 	    }
-	    
+
 	    if($line =~ /(\d+) packets input, (\d+) bytes, (\d)/){
 		$int->{'input'} = {};
 		$int->{'input'}->{'packets'} = $1;
@@ -446,21 +445,22 @@ sub _get_interface{
                 $int->{'name'} = $1;
                 next if(!defined($int->{'name'}));
                 $int->{'name'} =~ s/100GigabitEthernet/ethernet /;
+                $int->{'name'} =~ s/40GigabitEthernet/ethernet /;
                 $int->{'name'} =~ s/10GigabitEthernet/ethernet /;
                 $int->{'name'} =~ s/GigabitEthernet/ethernet /;
-                
+                $int->{'name'} =~ s/Ethernetmgmt/management /;
+
                 $line =~ /is (\S+), line protocol is (\S+)/;
                 $int->{'admin_status'} = $1;
                 $int->{'status'} = $2;
-                
+
                 if($int->{'admin_status'} eq 'disabled'){
                     $int->{'admin_status'} = 0;
                 }else{
                     $int->{'admin_status'} = 1;
                 }
-                
+
                 if(defined($int->{'status'})){
-                    
                     if($int->{'status'} eq 'up'){
                         $int->{'status'} = 1;
                     }elsif($int->{'status'} eq 'down'){
@@ -476,7 +476,6 @@ sub _get_interface{
     }
 
     return {parsed => $int, raw => $int_details};
-    
 }
 
 =head2 configure

--- a/t/08-get_tags_on_port.t
+++ b/t/08-get_tags_on_port.t
@@ -22,12 +22,15 @@ ok(defined($tags), "Tags returned a true value");
 
 my $is_ok = 1;
 
-for(my $i=0;$i<100;$i++){
-    if($tags->[$i] eq $i + 101){
-        
-    }else{
-        warn $tags->[$i] . " ne " . $i + 101 . "\n";
+my $testable_tags = {};
+foreach my $tag (@{$tags}) {
+    $testable_tags->{$tag} = 1;
+}
+for (my $i=0; $i < 100; $i++) {
+    if (!defined $testable_tags->{$i+101}) {
+        warn "Tag " . ($i+101) . " wasn't found";
         $is_ok = 0;
+        last;
     }
 }
 


### PR DESCRIPTION
By removing the call to workgroup_has_access_to_port, this change
removes unnecessary lookups, checks, and (most importantly) expensive
logging.

friendly_display_vlans previously expected a pre-sorted array of
vlans; This caused ranges to be incorrectly generated for results from
get_tags_on_port.

_get_interface requires vlan id translations when parsing output from show interface. Adding additional translations to handle management and 40Gb interfaces.