### PR TITLE
Changing regex pattern on web service and lookup on undef value

### DIFF
--- a/lib/VCE/Services/Switch.pm
+++ b/lib/VCE/Services/Switch.pm
@@ -120,7 +120,7 @@ sub _register_commands{
                 if($type eq 'vlan'){
                     $method->add_input_parameter( required => 1,
                                                   name => 'vlan_id',
-                                                  pattern => $GRNOC::WebService::Regex::NUMBER,
+                                                  pattern => $GRNOC::WebService::Regex::NAME_ID,
                                                   description => "the vlan to run the command for" );
                 }
 
@@ -202,8 +202,6 @@ sub _execute_command{
         return {results => [], error => {msg => $err}};
     }
 
-
-    $self->logger->info("Calling command $command->{'name'} on $p_ref->{'switch'}{'value'}");
     my $cmd_string;
     my $context_string;
     my $vars = {};


### PR DESCRIPTION
Because $p_ref->{'switchf'} is not always defined, remove it. This
fixes #67.

VLAN IDs in vce are not numbers: They are more like
`DC186112-9D5C-11E7-8125-02B6D77FA687`. Setting the regex for this
case. Fixes #66.