### PR TITLE
Adding polling for VLANs configured on each device

### DIFF
--- a/lib/VCE.pm
+++ b/lib/VCE.pm
@@ -163,6 +163,7 @@ sub _get_network_state {
 
             my $endpoints = [];
             foreach my $port (@{$response->{'results'}->{$vlan_id}->{'ports'}}) {
+                $port->{'port'} =~ s/^\s+|\s+$//g;
                 push(@{$endpoints}, { port => $port->{'port'} });
             }
 

--- a/lib/VCE.pm
+++ b/lib/VCE.pm
@@ -38,6 +38,7 @@ package VCE;
 use strict;
 use warnings;
 
+use AnyEvent;
 use Moo;
 use GRNOC::Log;
 use GRNOC::Config;
@@ -122,7 +123,56 @@ sub BUILD{
                                                              pass => $self->rabbit_mq->{'pass'},
                                                              exchange => 'VCE',
                                                              topic => 'VCE.Switch.RPC'));
+
+    $self->{'get_network_state_timer'} = AnyEvent->timer(
+        after => 30,
+        interval => 300,
+        cb => sub { $self->_get_network_state() }
+    );
+
     return $self;
+}
+
+sub _get_network_state {
+    my $self = shift;
+
+    $self->device_client->get_vlans( async_callback => sub {
+        my $response = shift;
+        if (defined $response->{'error'}) {
+            return $self->logger->error($response->{'error'});
+        }
+
+        foreach my $vlan_id (keys %{$response->{'results'}}) {
+            my $vlan = $self->network_model->get_vlan_details_by_number(number => $vlan_id);
+            if (!defined $vlan) {
+                my $switch_name = (keys(%{$self->config->{'switches'}}))[0];
+                my $workgroup = $self->access->get_admin_workgroup();
+                my $user = (keys %{$workgroup->{'user'}})[0];
+
+                my $id = $self->network_model->add_vlan(
+                    description => $response->{'results'}->{$vlan_id}->{'name'},
+                    workgroup => $workgroup->{'name'},
+                    vlan => $response->{'results'}->{$vlan_id}->{'vlan'},
+                    switch => $switch_name,
+                    endpoints => [],
+                    username => $user
+                );
+
+                $vlan = $self->network_model->get_vlan_details(vlan_id => $id);
+            }
+
+            my $endpoints = [];
+            foreach my $port (@{$response->{'results'}->{$vlan_id}->{'ports'}}) {
+                push(@{$endpoints}, { port => $port->{'port'} });
+            }
+
+            my $result = $self->network_model->set_vlan_endpoints(
+                vlan_id => $vlan->{'vlan_id'},
+                endpoints => $endpoints
+            );
+            $self->logger->debug('updated vlan: ' . Dumper($result));
+        }
+    });
 }
 
 sub _process_config{
@@ -153,6 +203,7 @@ sub _process_config{
 	$self->logger->debug("Processing workgroup: " . Data::Dumper::Dumper($workgroup));
 	my $grp = {};
 	$grp->{'name'} = $workgroup->{'name'};
+    $grp->{'admin'} = $workgroup->{'admin'};
 	$grp->{'description'} = $workgroup->{'description'};
 	$grp->{'user'} = $workgroup->{'user'};
 	$workgroups{$grp->{'name'}} = $grp;
@@ -395,7 +446,7 @@ sub get_interfaces_operational_state {
         $self->logger->error("get_interfaces_operational_state: Switch not specified");
         return;
     }
-    
+
     return $self->device_client->get_interfaces_op()->{'results'};
 }
 
@@ -526,7 +577,7 @@ sub is_tag_available{
 }
 
 =head2 validate_circuit
-    
+
 =cut
 
 sub validate_circuit{

--- a/lib/VCE/Access.pm
+++ b/lib/VCE/Access.pm
@@ -550,4 +550,16 @@ sub get_switches{
 
 }
 
+sub get_admin_workgroup {
+    my $self = shift;
+
+    foreach my $wgroup (keys %{$self->config->{'workgroups'}}) {
+        if (defined $self->config->{'workgroups'}->{$wgroup}->{'admin'}) {
+            return $self->config->{'workgroups'}->{$wgroup};
+        }
+    }
+
+    return undef;
+}
+
 1;

--- a/lib/VCE/NetworkModel.pm
+++ b/lib/VCE/NetworkModel.pm
@@ -323,6 +323,7 @@ sub set_vlan_endpoints {
 
     if (defined $self->nm->{'vlans'}->{$params{'vlan_id'}}) {
         $self->nm->{'vlans'}->{$params{'vlan_id'}}->{'endpoints'} = $params{'endpoints'};
+        $self->_write_network_model();
         return $self->nm->{'vlans'}->{$params{'vlan_id'}};
     }
 

--- a/lib/VCE/NetworkModel.pm
+++ b/lib/VCE/NetworkModel.pm
@@ -292,4 +292,42 @@ sub get_vlan_details{
     return;
 }
 
+sub get_vlan_details_by_number {
+    my $self = shift;
+    my %params = @_;
+
+    if(!defined $params{'number'}) {
+        $self->logger->error("No VLAN number specified.");
+        return;
+    }
+
+    foreach my $vlan_id (keys %{$self->nm->{'vlans'}}) {
+        my $vlan = $self->nm->{'vlans'}->{$vlan_id};
+        if ($vlan->{'vlan'} eq $params{'number'}) {
+            return $vlan;
+        }
+    }
+
+    $self->logger->error("No VLAN with number: " . $params{'number'});
+    return undef;
+}
+
+sub set_vlan_endpoints {
+    my $self = shift;
+    my %params = @_;
+
+    if (!defined $params{'vlan_id'}) {
+        $self->logger->error("No VLAN ID specified");
+        return;
+    }
+
+    if (defined $self->nm->{'vlans'}->{$params{'vlan_id'}}) {
+        $self->nm->{'vlans'}->{$params{'vlan_id'}}->{'endpoints'} = $params{'endpoints'};
+        return $self->nm->{'vlans'}->{$params{'vlan_id'}};
+    }
+
+    $self->logger->error("No VLAN with ID: " . $params{'vlan_id'});
+    return undef;
+}
+
 1;


### PR DESCRIPTION
If a VLAN is modified switch side, then VCE should notice the
modification. This change polls the VLANs from the device via NetConf
and compares each VLANs' configured interfaces against VCE's network
model. If a difference is found, the state found on the device is
saved to VCE's network model.