### PR TITLE
Per-VLAN Spanning Tree

### DIFF
--- a/lib/VCE.pm
+++ b/lib/VCE.pm
@@ -21,11 +21,7 @@
 ##   limitations under the License.
 #
 
-=head1 NAME
-
-VCE - VCE Virtual Customer Equipement
-
-=head1 VERSION
+=head1 VCE - VCE Virtual Customer Equipement
 
 Version 0.2.3
 
@@ -65,17 +61,17 @@ has device_client => (is => 'rwp');
 has rabbit_mq => (is => 'rwp');
 
 =head1 SYNOPSIS
+
 This is a module to provide a simplified object oriented way to connect to
 and interact with the VCE database.
-
-Some examples:
 
     use VCE;
 
     my $vce = VCE->new();
-    my $is_in_workgroup = $vce->access->user_in_workgroup( username => 'aragusa@iu.edu',
-                                                           workgroup => 'ajco');
-
+    my $is_in_workgroup = $vce->access->user_in_workgroup(
+      username => 'aragusa@iu.edu',
+      workgroup => 'ajco'
+    );
 
 =cut
 
@@ -465,7 +461,6 @@ sub get_switches_operational_state{
     }
 
     my $switches = $self->get_switches( workgroup => $params{'workgroup'});
-
     foreach my $switch (@$switches){
         my %int_state;
         $switch->{'status'} = $self->_get_switch_status( switch => $switch );
@@ -512,25 +507,25 @@ sub get_switches_operational_state{
         $switch->{'vlans'} = \@vlans;
     }
 
-            
     return $switches;
 }
-
-
 
 sub _get_switch_status{
     my $self = shift;
     my %params = @_;
 
-    my $state = $self->device_client->get_device_status()->{'results'};
-    $self->logger->error("SWITCH STATUS: " . Data::Dumper::Dumper($state));
-    if(!defined($state)){
-        return "Unknown";
+    my $state = $self->device_client->get_device_status();
+    if (defined $state->{'error'}) {
+        $self->logger->error($state->{'error'});
+        return 'Unknown';
     }
-    if($state->{'status'} == 1){
-        return "Up";
-    }else{
-        return "Down";
+
+    if ($state->{'results'} == 1) {
+        return 'Up';
+    } elsif ($state->{'results'} == 0) {
+        return 'Down';
+    } else {
+        return 'Unknown';
     }
 }
 
@@ -538,15 +533,15 @@ sub _get_interface_status{
     my $self = shift;
     my %params = @_;
 
-    my $state = $self->device_client->get_interface_status(interface => $params{'interface'})->{'results'};
-    if (!defined $state || defined $state->{'error'}) {
-        $self->logger->error("Interface Status: " . Data::Dumper::Dumper($state));
+    my $state = $self->device_client->get_interface_status(interface => $params{'interface'});
+    if (defined $state->{'error'}) {
+        $self->logger->error($state->{'error'});
         return "Unknown";
     }
 
-    if ($state->{'status'} == 1) {
+    if ($state->{'results'} == 1) {
         return 'Up';
-    } elsif ($state->{'status'} == 0) {
+    } elsif ($state->{'results'} == 0) {
         return 'Down';
     } else {
         return 'Unknown';

--- a/lib/VCE/Device/Brocade/MLXe/5_8_0.pm
+++ b/lib/VCE/Device/Brocade/MLXe/5_8_0.pm
@@ -300,6 +300,120 @@ sub get_interfaces {
     return {interfaces => \%interfaces, raw => $raw};
 }
 
+=head2 vlan_spanning_tree
+
+    my ($res, $err) = vlan_spanning_tree($vlan_id);
+
+vlan_spanning_tree enables spanning tree on VLAN $vlan_id. Returns a
+response and error; The error is undef if nothing failed.
+
+L<nos-601-netconfguide.pdf|https://www.brocade.com/content/dam/common/documents/content-types/netconf-operations-guide/nos-601-netconfguide.pdf> pg. 22
+
+=cut
+sub vlan_spanning_tree {
+    my $self    = shift;
+    my $vlan_id = shift;
+
+    my $res;
+    my $err;
+
+    my $ok = $self->configure();
+    if (!$ok) {
+        $err = "Could not enter configure mode.";
+        $self->logger->error($err);
+        return $res, $err;
+    }
+
+    $ok = $self->set_context("vlan $vlan_id");
+    if (!$ok) {
+        $err = "Could not enter vlan configure mode.";
+        $self->logger->error($err);
+        return $res, $err;
+    }
+
+    ($res, $err) = $self->issue_command("spanning-tree", "#");
+    if ($err) {
+        $self->logger->error($err);
+        return $res, $err;
+    }
+
+    ($res, $err) = $self->issue_command("write mem", "#");
+    if ($err) {
+        $self->logger->error($err);
+    }
+
+    $ok = $self->exit_context();
+    if (!$ok) {
+        $err = "Failed to exit context.";
+        $self->logger->warn($err);
+    }
+
+    $ok = $self->exit_configure();
+    if (!$ok) {
+        $err = "Failed to exit configure.";
+        $self->logger->warn($err);
+    }
+
+    return $res, $err;
+}
+
+=head2 no_vlan_spanning_tree
+
+    my ($res, $err) = no_vlan_spanning_tree($vlan_id);
+
+no_vlan_spanning_tree disables spanning tree on VLAN $vlan_id. Returns
+a response and error; The error is undef if nothing failed.
+
+L<nos-601-netconfguide.pdf|https://www.brocade.com/content/dam/common/documents/content-types/netconf-operations-guide/nos-601-netconfguide.pdf> pg. 22
+
+=cut
+sub no_vlan_spanning_tree {
+    my $self    = shift;
+    my $vlan_id = shift;
+
+    my $res;
+    my $err;
+
+    my $ok = $self->configure();
+    if (!$ok) {
+        $err = "Could not enter configure mode.";
+        $self->logger->error($err);
+        return $res, $err;
+    }
+
+    $ok = $self->set_context("vlan $vlan_id");
+    if (!$ok) {
+        $err = "Could not enter vlan configure mode.";
+        $self->logger->error($err);
+        return $res, $err;
+    }
+
+    ($res, $err) = $self->issue_command("no spanning-tree", "#");
+    if ($err) {
+        $self->logger->error($err);
+        return $res, $err;
+    }
+
+    ($res, $err) = $self->issue_command("write mem", "#");
+    if ($err) {
+        $self->logger->error($err);
+    }
+
+    $ok = $self->exit_context();
+    if (!$ok) {
+        $err = "Failed to exit context.";
+        $self->logger->warn($err);
+    }
+
+    $ok = $self->exit_configure();
+    if (!$ok) {
+        $err = "Failed to exit configure.";
+        $self->logger->warn($err);
+    }
+
+    return $res, $err;
+}
+
 =head2 vlan_description
 
 vlan_description sets vlan $vlan_id's description to $desc. Returns a


### PR DESCRIPTION
Adding support for per-VLAN spanning tree. Spanning tree is enabled on a per-VLAN basis whenever a single VLAN contains more than two endpoints. Spanning tree will be disabled whenever a VLAN contains less than three endpoints. Fixes #80.
