### PR TITLE
VLAN edit permissions for port owners

### DIFF
--- a/lib/VCE/Access.pm
+++ b/lib/VCE/Access.pm
@@ -571,4 +571,55 @@ sub get_admin_workgroup {
     return undef;
 }
 
+=head2 port_owner
+
+    my $ok = port_owner($workgroup, $switch, $port);
+
+port_owner returns 1 if C<$workgroup> owns C<($switch, $port)>.
+
+=cut
+sub port_owner {
+    my $self      = shift;
+    my $workgroup = shift;
+    my $switch    = shift;
+    my $port      = shift;
+
+
+    if (!defined $self->config->{switches}->{$switch'}) {
+        $self->logger->error("Couldn't find a switch named $switch.");
+        return 0;
+    }
+
+    if (!defined $self->config->{switches}->{$switch}->{ports}->{$port}) {
+        $self->logger->error("Couldn't find a port named $port on $switch.");
+        return 0;
+    }
+
+    my $port_config = $self->config->{switches}->{$switch}->{ports}->{$port};
+
+    if ($port_config->{'owner'} ne $workgroup) {
+        $self->logger->warn("Workgroup $workgroup doesn't own $port on $switch.");
+        return 0;
+    }
+
+    return 1;
+}
+
+=head2 vlan_owner
+
+    my $ok = vlan_owner($workgroup, $vlan_uuid);
+
+vlan_owner returns 1 if C<$workgroup> created C<$vlan_uuid>.
+
+=cut
+
+=head2 vlan_permittee
+
+    my $ok = vlan_permittee($workgroup, $swich, $port, $vlan);
+
+vlan_permittee returns 1 if C<$workgroup> has the right to provision
+C<$vlan> on C<($switch, $port)>.
+
+=cut
+
 1;

--- a/lib/VCE/NetworkModel.pm
+++ b/lib/VCE/NetworkModel.pm
@@ -104,6 +104,8 @@ sub add_vlan{
     my $self = shift;
     my %params = @_;
 
+    warn Dumper(\%params);
+
     $self->logger->error("Adding a VLAN");
 
     my $obj = {};
@@ -222,7 +224,8 @@ sub delete_vlan{
       switch    => $string  (optional)
     );
 
-get_vlans returns a list of vlans filtered by C<workgroup> and C<switch>.
+get_vlans returns a list of vlan UUIDs filtered by C<workgroup> and
+C<switch>.
 
 =cut
 sub get_vlans{
@@ -247,6 +250,12 @@ sub get_vlans{
 }
 
 =head2 get_vlan_details
+
+    my $vlan = get_vlan_details(
+      vlan_id => $string
+    );
+
+get_vlan_details returns the VLAN associated with UUID C<$vlan_id>.
 
 =cut
 sub get_vlan_details{

--- a/lib/VCE/NetworkModel.pm
+++ b/lib/VCE/NetworkModel.pm
@@ -217,7 +217,12 @@ sub delete_vlan{
 
 =head2 get_vlans
 
-    returns a list of vlans if specified a list of vlans for a workgroup
+    my $vlans = get_vlans(
+      workgroup => $string, (optional)
+      switch    => $string  (optional)
+    );
+
+get_vlans returns a list of vlans filtered by C<workgroup> and C<switch>.
 
 =cut
 sub get_vlans{
@@ -226,27 +231,16 @@ sub get_vlans{
 
     my @vlans;
 
-    if(!defined($params{'workgroup'})){
-        foreach my $vlan (keys(%{$self->nm->{'vlans'}})){
-            push(@vlans, $vlan);
+    foreach my $uuid (keys %{$self->nm->{'vlans'}}) {
+        if (defined $params{'workgroup'} && $self->nm->{'vlans'}->{$uuid}->{'workgroup'} ne $params{'workgroup'}) {
+            next;
         }
-    }else{
-        foreach my $vlan_id (keys(%{$self->nm->{'vlans'}})){
-            my $vlan = $self->nm->{'vlans'}->{$vlan_id};
-            if($vlan->{'workgroup'} eq $params{'workgroup'}){
-                push(@vlans, $vlan_id);
-            }
-        }
-    }
 
-    if (defined $params{'switch'}) {
-        my @final;
-        foreach my $vlan (@vlans){
-            if($self->nm->{'vlans'}->{$vlan}->{'switch'} eq $params{'switch'}){
-                push(@final, $vlan);
-            }
+        if (defined $params{'switch'} && $self->nm->{'vlans'}->{$uuid}->{'switch'} ne $params{'switch'}) {
+            next;
         }
-        return \@final;
+
+        push(@vlans, $uuid);
     }
 
     return \@vlans;

--- a/lib/VCE/NetworkModel.pm
+++ b/lib/VCE/NetworkModel.pm
@@ -9,6 +9,7 @@ use Moo;
 use JSON::XS;
 use GRNOC::Log;
 
+use Data::Dumper;
 use Data::UUID;
 
 has logger => (is => 'rwp');

--- a/lib/VCE/Services/Access.pm
+++ b/lib/VCE/Services/Access.pm
@@ -674,13 +674,13 @@ sub get_vlans{
             next;
         }
 
-        # Check if an Endpoint on the VLAN is owned by $workgroup.
+        # If $workgroup owns a port on $vlan he should be able to see
+        # it's details.
         foreach my $endpoint (@{$vlan_details->{'endpoints'}}) {
-            my $ok = $self->vce->access->workgroup_has_access_to_port(
-                workgroup => $workgroup,
-                switch    => $vlan_details->{'switch'},
-                port      => $endpoint->{'port'},
-                vlan      => $vlan_details->{'vlan'}
+            my ($ok, undef) = $self->vce->access->is_port_owner(
+                $workgroup,
+                $vlan_details->{switch},
+                $endpoint->{port}
             );
             if ($ok) {
                 push(@vlans, $vlan_details);

--- a/lib/VCE/Services/Access.pm
+++ b/lib/VCE/Services/Access.pm
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 
 use Moo;
-
+use Data::Dumper;
 use VCE;
 
 use GRNOC::Log;
@@ -650,7 +650,6 @@ sub get_switches{
 =head2 get_vlans
 
 =cut
-
 sub get_vlans{
     my $self = shift;
     my $m_ref = shift;
@@ -664,12 +663,30 @@ sub get_vlans{
         return {results => [], error => {msg => "User $user not in specified workgroup $workgroup"}};
     }
 
-    my $vlans = $self->vce->network_model->get_vlans(workgroup => $workgroup);
+    my $vlans = $self->vce->network_model->get_vlans();
 
     my @vlans;
-    foreach my $vlan (@$vlans){
-        my $vlan_details = $self->vce->network_model->get_vlan_details( vlan_id => $vlan );
-        push(@vlans, $vlan_details);
+    foreach my $vlan (@$vlans) {
+        my $vlan_details = $self->vce->network_model->get_vlan_details(vlan_id => $vlan);
+        # Check if the VLAN is owned by $workgroup.
+        if ($vlan_details->{'workgroup'} eq $workgroup) {
+            push(@vlans, $vlan_details);
+            next;
+        }
+
+        # Check if an Endpoint on the VLAN is owned by $workgroup.
+        foreach my $endpoint (@{$vlan_details->{'endpoints'}}) {
+            my $ok = $self->vce->access->workgroup_has_access_to_port(
+                workgroup => $workgroup,
+                switch    => $vlan_details->{'switch'},
+                port      => $endpoint->{'port'},
+                vlan      => $vlan_details->{'vlan'}
+            );
+            if ($ok) {
+                push(@vlans, $vlan_details);
+                last;
+            }
+        }
     }
 
     return {results => [{vlans => \@vlans}]};
@@ -678,7 +695,6 @@ sub get_vlans{
 =head2 get_vlan_details
 
 =cut
-
 sub get_vlan_details{
     my $self = shift;
     my $m_ref = shift;
@@ -696,13 +712,29 @@ sub get_vlan_details{
     my $vlan = $self->vce->network_model->get_vlan_details(vlan_id => $p_ref->{'vlan_id'}{'value'});
 
     my $workgroup_owns_vlan = $vlan->{'workgroup'} eq $workgroup;
-    if (!$workgroup_owns_vlan) {
-        my $error = "Workgroup $workgroup does not have access to vlan " . $p_ref->{'vlan_id'}{'value'};
-        $self->logger->error($error);
-        return {error => {'msg' => $error}};
+    my $workgroup_owns_port = 0;
+
+    # Check if an Endpoint on the VLAN is owned by $workgroup.
+    foreach my $endpoint (@{$vlan->{'endpoints'}}) {
+        my $ok = $self->vce->access->workgroup_has_access_to_port(
+            workgroup => $workgroup,
+            switch    => $vlan->{'switch'},
+            port      => $endpoint->{'port'},
+            vlan      => $vlan->{'vlan'}
+        );
+        if ($ok) {
+            $workgroup_owns_port = 1;
+            last;
+        }
     }
 
-    return {results => [{circuit => $vlan}]};
+    if ($workgroup_owns_vlan || $workgroup_owns_port) {
+        return {results => [{circuit => $vlan}]};
+    }
+
+    my $error = "Workgroup $workgroup does not have access to vlan " . $p_ref->{'vlan_id'}{'value'};
+    $self->logger->error($error);
+    return {error => {'msg' => $error}};
 }
 
 1;

--- a/lib/VCE/Services/Access.pm
+++ b/lib/VCE/Services/Access.pm
@@ -653,7 +653,6 @@ sub get_switches{
 
 sub get_vlans{
     my $self = shift;
-    
     my $m_ref = shift;
     my $p_ref = shift;
 
@@ -661,24 +660,19 @@ sub get_vlans{
 
     my $workgroup = $p_ref->{'workgroup'}{'value'};
 
-    if($self->vce->access->user_in_workgroup( username => $user,
-                                              workgroup => $workgroup )){
-        
-        my $vlans = $self->vce->network_model->get_vlans( workgroup => $workgroup);
-
-        my @vlans;
-        foreach my $vlan (@$vlans){
-            my $vlan_details = $self->vce->network_model->get_vlan_details( vlan_id => $vlan );
-            push(@vlans, $vlan_details);
-        }
-
-        
-
-        return {results => [{vlans => \@vlans}]};
-    }else{
+    if (!$self->vce->access->user_in_workgroup(username => $user, workgroup => $workgroup)) {
         return {results => [], error => {msg => "User $user not in specified workgroup $workgroup"}};
     }
 
+    my $vlans = $self->vce->network_model->get_vlans(workgroup => $workgroup);
+
+    my @vlans;
+    foreach my $vlan (@$vlans){
+        my $vlan_details = $self->vce->network_model->get_vlan_details( vlan_id => $vlan );
+        push(@vlans, $vlan_details);
+    }
+
+    return {results => [{vlans => \@vlans}]};
 }
 
 =head2 get_vlan_details

--- a/lib/VCE/Services/Provisioning.pm
+++ b/lib/VCE/Services/Provisioning.pm
@@ -206,6 +206,12 @@ sub provision_vlan{
         return {results => [], error => {msg => "User $user not in specified workgroup $workgroup"}};
     }
 
+    my ($ok, $error) = $self->vce->access->is_vlan_permittee($workgroup, $switch, $ports, $vlan);
+    if (!$ok) {
+        $self->logger->error($error);
+        return {results => [], error => {msg => $error}};
+    }
+
     my $vlan_id = $self->vce->provision_vlan(
         workgroup => $workgroup,
         description => $description,
@@ -268,18 +274,28 @@ sub edit_vlan{
     my $description = $p_ref->{'description'}{'value'};
     my $vlan_id = $p_ref->{'vlan_id'}{'value'};
 
-    #verify user in workgroup
-    if($self->vce->access->user_in_workgroup( username => $user,
-                                              workgroup => $workgroup )){
+    # BEGIN - Permissions check
+    # There are two cases when a VLAN may be edited. The first
+    # requires that the VLAN is owned by $workgroup and that the
+    # workgroup has been allocated the appropriate VLANs on all of
+    # $ports.
+    #
+    # The second case is when a port owner decides a VLAN should
+    # be removed from its port. This case requires the ports being
+    # removed are owned by $workgroup, and that no other ports are
+    # added.
+    my $valid_user = $self->vce->access->user_in_workgroup(username => $user, workgroup => $workgroup);
+    if (!$valid_user) {
+        my $error = "User $user not in specified workgroup $workgroup.";
+        $self->logger->error($error);
+        return {results => [], error => {msg => $error}};
+    }
 
-        my $details = $self->vce->network_model->get_vlan_details( vlan_id => $vlan_id );
+    my $details       = $self->vce->network_model->get_vlan_details( vlan_id => $vlan_id );
+    my $is_vlan_owner = $details->{'workgroup'} eq $workgroup;
+    my ($is_vlan_permittee, undef) = $self->vce->access->is_vlan_permittee($workgroup, $switch, $ports, $vlan);
 
-        # if ($details->{'workgroup'} ne $workgroup) {
-        #     my $error = "Workgroup $workgroup is not allowed to edit vlan $vlan_id.";
-        #     $self->logger->error($error);
-        #     return {results => [], error => {msg => $error}};
-        # }
-
+    if (!($is_vlan_owner && $is_vlan_permittee)) {
         my $mk_interfaces = [];
         my $rm_interfaces = [];
 
@@ -310,105 +326,84 @@ sub edit_vlan{
             }
         }
 
-        my $vlan_owner     = $details->{'workgroup'} eq $workgroup;
-        my $vlan_permittee = $self->vce->validate_circuit(
-            workgroup   => $workgroup,
-            switch      => $switch,
-            port        => $ports,
-            vlan        => $vlan
-        );
-
         my $rm_interfaces_count = @{$rm_interfaces};
-        my $rm_interfaces_owner = 0;
+        my $mk_interfaces_count = @{$mk_interfaces};
+        my $is_rm_interfaces_owner = 0;
         if ($rm_interfaces_count > 0) {
-            $rm_interfaces_owner = 1;
+            $is_rm_interfaces_owner = 1;
         }
 
         foreach my $intf (@{$rm_interfaces}) {
-            my $intf_owner = $self->vce->access->workgroup_owns_port(
-                workgroup => $workgroup,
-                switch    => $switch,
-                port      => $intf
+            ($is_rm_interfaces_owner, undef) = $self->vce->access->is_port_owner(
+                $workgroup,
+                $switch,
+                $intf
             );
-            if (!$intf_owner) {
-                $rm_interfaces_owner = 0;
+            if (!$is_rm_interfaces_owner) {
                 last;
             }
         }
 
-        # There are two cases when a VLAN may be edited. The first
-        # requires that the VLAN is owned by $workgroup and that the
-        # workgroup has been allocated the appropriate VLANs on all of
-        # $ports.
-        #
-        # The second case is when a port owner decides a VLAN should
-        # be removed from its port. This case requires the ports being
-        # removed are owned by $workgroup, and that no other ports are
-        # added.
-        if (!($vlan_owner && $vlan_permittee) && !($rm_interfaces_owner && @{$mk_interfaces} == 0)) {
-            warn "vlan_owner: $vlan_owner vlan_permittee: $vlan_permittee rm_int_owner: $rm_interfaces_owner";
+        if (!($is_rm_interfaces_owner && $mk_interfaces_count == 0)) {
             my $error = "Workgroup $workgroup not authorized to make this change.";
+            warn "vlan_owner: $is_vlan_owner vlan_permittee: $is_vlan_permittee rm_int_owner: $is_rm_interfaces_owner";
             $self->logger->error($error);
             return {results => [{success => 0, vlan_id => $vlan_id}], error => {msg => $error}};
         }
-
-        my $endpoints = [];
-        foreach my $e (@{$details->{'endpoints'}}) {
-            push(@{$endpoints}, $e->{'port'});
-        }
-
-        my $response = $self->switch->no_interface_tagged(port => $endpoints, vlan => $vlan);
-        if (defined $response->{'error'}) {
-            $self->logger->error($response->{'error'});
-            return {results => [{success => 0, vlan_id => $vlan_id}], error => {msg => $response->{'error'}}};
-        }
-
-        $self->vce->delete_vlan(vlan_id => $vlan_id, workgroup => $workgroup);
-        $self->vce->provision_vlan(
-            vlan_id => $vlan_id,
-            workgroup => $workgroup,
-            description => $description,
-            username => $user,
-            switch => $switch,
-            port => $ports,
-            vlan => $vlan,
-            skip_validation => 1
-        );
-
-        my $details = $self->vce->network_model->get_vlan_details( vlan_id => $vlan_id);
-        my $endpoints = [];
-        my $endpoint_count = 0;
-
-        foreach my $e (@{$details->{'endpoints'}}) {
-            push(@{$endpoints}, $e->{'port'});
-            $endpoint_count++;
-        }
-
-        my $response = $self->switch->interface_tagged(port => $endpoints, vlan => $vlan);
-        if (defined $response->{'error'}) {
-            $self->logger->error($response->{'error'});
-
-            return {results => [{success => 0, vlan_id => $vlan_id}], error => {msg => $response->{'error'}}};
-        }
-
-        # Multipoint VLANs should have spanning-tree enabled.
-        my $response;
-        if ($endpoint_count > 2) {
-            $response = $self->switch->vlan_spanning_tree(vlan => $vlan);
-        } else {
-            $response = $self->switch->no_vlan_spanning_tree(vlan => $vlan);
-        }
-        if (defined $response->{'error'}) {
-            $self->logger->warn($response->{'error'});
-        }
-
-        $self->_send_vlan_description($description, $switch, $vlan );
-        return {results => [{success => 1, vlan_id => $vlan_id}]};
-    }else{
-        my $error = "User $user not in specified workgroup $workgroup.";
-        $self->logger->error($error);
-        return {results => [], error => {msg => $error}};
     }
+    # END
+
+    my $endpoints = [];
+    foreach my $e (@{$details->{'endpoints'}}) {
+        push(@{$endpoints}, $e->{'port'});
+    }
+
+    my $response = $self->switch->no_interface_tagged(port => $endpoints, vlan => $vlan);
+    if (defined $response->{'error'}) {
+        $self->logger->error($response->{'error'});
+        return {results => [{success => 0, vlan_id => $vlan_id}], error => {msg => $response->{'error'}}};
+    }
+
+    $self->vce->delete_vlan(vlan_id => $vlan_id, workgroup => $workgroup);
+    $self->vce->provision_vlan(
+        vlan_id => $vlan_id,
+        workgroup => $workgroup,
+        description => $description,
+        username => $user,
+        switch => $switch,
+        port => $ports,
+        vlan => $vlan
+    );
+
+    my $details = $self->vce->network_model->get_vlan_details( vlan_id => $vlan_id);
+    my $endpoints = [];
+    my $endpoint_count = 0;
+
+    foreach my $e (@{$details->{'endpoints'}}) {
+        push(@{$endpoints}, $e->{'port'});
+        $endpoint_count++;
+    }
+
+    my $response = $self->switch->interface_tagged(port => $endpoints, vlan => $vlan);
+    if (defined $response->{'error'}) {
+        $self->logger->error($response->{'error'});
+
+        return {results => [{success => 0, vlan_id => $vlan_id}], error => {msg => $response->{'error'}}};
+    }
+
+    # Multipoint VLANs should have spanning-tree enabled.
+    my $response;
+    if ($endpoint_count > 2) {
+        $response = $self->switch->vlan_spanning_tree(vlan => $vlan);
+    } else {
+        $response = $self->switch->no_vlan_spanning_tree(vlan => $vlan);
+    }
+    if (defined $response->{'error'}) {
+        $self->logger->warn($response->{'error'});
+    }
+
+    $self->_send_vlan_description($description, $switch, $vlan );
+    return {results => [{success => 1, vlan_id => $vlan_id}]};
 }
 
 =head2 delete_vlan
@@ -424,15 +419,12 @@ sub delete_vlan{
     my $workgroup = $p_ref->{'workgroup'}{'value'};
     my $vlan_id = $p_ref->{'vlan_id'}{'value'};
 
-    # Permissions check
-    my $in_workgroup = $self->vce->access->user_in_workgroup(
-        username  => $user,
-        workgroup => $workgroup
-    );
+    my $in_workgroup = $self->vce->access->user_in_workgroup(username  => $user, workgroup => $workgroup);
     if (!$in_workgroup) {
         return {results => [], error => {msg => "User $user not in specified workgroup $workgroup"}};
     }
 
+    # Check if is_vlan_owner
     my $details = $self->vce->network_model->get_vlan_details( vlan_id => $vlan_id);
     if ($details->{'workgroup'} ne $workgroup) {
         return {results => [], error => {msg => "Workgroup $workgroup is not allowed to edit vlan $vlan_id"}};

--- a/t/104-get_vlans.t
+++ b/t/104-get_vlans.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 9;
+use Test::More tests => 12;
 
 use GRNOC::WebService::Client;
 use Data::Dumper;
@@ -21,9 +21,12 @@ my $vlans = $client->get_vlans( workgroup => 'ajco' );
                                 
 
 ok(defined($vlans), "vlans result was defined for AJ");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 1, "Proper number of vlans returned");
+
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "Proper number of vlans returned");
 ok($vlans->{'results'}->[0]->{'vlans'}->[0]->{'vlan_id'} eq '979f9708-7102-4762-8a6a-8e30ed80b88c', "First vlan returned properly");
-ok($vlans->{'results'}->[0]->{'vlans'}->[1]->{'vlan_id'} eq 'b0c0103e-b2dc-47cd-a687-c73dd9100fd2', "Second vlan returned properly");
+# eth0/2 is owned by ajco; This means all VLANs that use this port must be returned by GET VLANs.
+ok($vlans->{'results'}->[0]->{'vlans'}->[1]->{'vlan_id'} eq '2806baa4-173c-4bdd-b552-c063a82e232f', "Second vlan returned properly");
+ok($vlans->{'results'}->[0]->{'vlans'}->[2]->{'vlan_id'} eq 'b0c0103e-b2dc-47cd-a687-c73dd9100fd2', "Third vlan returned properly");
 
 $vlans = $client->get_vlans( workgroup => 'edco' );
 ok(defined($vlans->{'error'}) && $vlans->{'error'}->{'msg'} eq 'User aragusa not in specified workgroup edco');
@@ -42,6 +45,9 @@ $vlans = $client2->get_vlans( workgroup => 'edco');
 
 ok(defined($vlans), "Got a valid response");
 
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 0, "Got the proper number of VLANs back");
-
-ok($vlans->{'results'}->[0]->{'vlans'}->[0]->{'vlan_id'} eq '2806baa4-173c-4bdd-b552-c063a82e232f', "Got the proper vlan ID back");
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "Got the proper number of VLANs back");
+# eth0/1 is owned by edco; This means all VLANs that use this port must be returned by GET VLANs.
+ok($vlans->{'results'}->[0]->{'vlans'}->[0]->{'vlan_id'} eq '979f9708-7102-4762-8a6a-8e30ed80b88c', "First vlan returned properly");
+ok($vlans->{'results'}->[0]->{'vlans'}->[1]->{'vlan_id'} eq '2806baa4-173c-4bdd-b552-c063a82e232f', "Second vlan returned properly");
+# eth0/1 is owned by edco; This means all VLANs that use this port must be returned by GET VLANs.
+ok($vlans->{'results'}->[0]->{'vlans'}->[2]->{'vlan_id'} eq 'b0c0103e-b2dc-47cd-a687-c73dd9100fd2', "Third vlan returned properly");

--- a/t/105-get_vlan_details.t
+++ b/t/105-get_vlan_details.t
@@ -22,35 +22,30 @@ my $vlan = $client->get_vlan_details( workgroup => 'ajco',
 
 ok(defined($vlan), "vlan result was defined for AJ");
 
-cmp_deeply($vlan, {
-    'results' => [
-        {
-            'circuit' => {
-                'workgroup' => 'ajco',
-                'status' => 'Active',
-                'create_time' => 1479158369,
-                'description' => 'test',
+cmp_deeply($vlan->{results}->[0], {
+    'circuit' => {
+        'workgroup' => 'ajco',
+        'status' => 'Active',
+        'create_time' => 1479158369,
+        'description' => 'test',
+        'switch' => 'foobar',
+        'vlan' => '102',
+        'endpoints' => [
+            {
                 'switch' => 'foobar',
-                'vlan' => '102',
-                'endpoints' => [
-                    {
-                        'switch' => 'foobar',
-                        'tag' => '102',
-                        'port' => 'eth0/1'
-                    },
-                    {
-                        'switch' => 'foobar',
-                        'tag' => '102',
-                        'port' => 'eth0/2'
-                    }
-                    ],
-                'username' => 'aragusa',
-                'vlan_id' => '979f9708-7102-4762-8a6a-8e30ed80b88c'
+                'tag' => '102',
+                'port' => 'eth0/1'
+            },
+            {
+                'switch' => 'foobar',
+                'tag' => '102',
+                'port' => 'eth0/2'
             }
-        }
-        ]
-           }
-    );
+        ],
+        'username' => 'aragusa',
+        'vlan_id' => '979f9708-7102-4762-8a6a-8e30ed80b88c'
+    }
+});
 
 $vlan = $client->get_vlan_details( workgroup => 'ajco',
                                    vlan_id => 'b0c0103e-b2dc-47cd-a687-c73dd9100fd2');
@@ -92,8 +87,7 @@ $vlan = $client->get_vlan_details( workgroup => 'ajco',
                                    vlan_id => '2806baa4-173c-4bdd-b552-c063a82e232f');
 
 ok(defined($vlan), "vlan result was defined for AJ");
-
-ok($vlan->{'error'}->{'msg'} eq 'Workgroup ajco does not have access to vlan 2806baa4-173c-4bdd-b552-c063a82e232f');
+ok($vlan->{results}->[0]->{circuit}->{workgroup} eq 'edco', 'Got VLAN because of workgroup owned port.');
 
 my $client2 = GRNOC::WebService::Client->new( url => 'http://localhost:8529/vce/services/access.cgi',
                                               realm => 'VCE',

--- a/t/200-provision_vlan.t
+++ b/t/200-provision_vlan.t
@@ -77,7 +77,7 @@ my $ua = AnyEvent::HTTP::LWP::UserAgent->new;
 my $vlans = $client->get_vlans( workgroup => 'ajco' );
 
 ok(defined($vlans), "Got a response");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 1, "Expected circuits found!");
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "Expected circuits found!");
 
 my $vlan;
 my $req = make_request({ method => 'add_vlan', 
@@ -91,8 +91,7 @@ my $response = $ua->simple_request_async($req)->recv;
 if($response->is_success){
     my $content = $response->content;
     $vlan = decode_json($content);
-}                               
-
+}
 
 ok(defined($vlan), "got a response");
 ok($vlan->{'results'}->[0]->{'success'} == 1, "Success provisioning!");
@@ -101,7 +100,7 @@ ok(defined($vlan->{'results'}->[0]->{'vlan_id'}), "Got a VLAN ID Back!");
 $vlans = $client->get_vlans( workgroup => 'ajco');
 
 ok(defined($vlans), "Got a valid response");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "We now see that we have a VLAN!");
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 3, "We now see that we have a VLAN!");
 
 my $vlan_details = $client->get_vlan_details( vlan_id => $vlan->{'results'}->[0]->{'vlan_id'},
                                               workgroup => 'ajco');
@@ -172,7 +171,7 @@ ok($vlan->{'error'}->{'msg'} eq 'Unable to add circuit to network model', "Retur
 
 $vlans = $client->get_vlans( workgroup => 'ajco');
 ok(defined($vlans), "Got a valid response");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "Making sure we have the right number of circuits still");
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 3, "Making sure we have the right number of circuits still");
 
 
 $req = make_request({method => 'add_vlan',

--- a/t/201-edit_vlan.t
+++ b/t/201-edit_vlan.t
@@ -76,7 +76,7 @@ my $ua = AnyEvent::HTTP::LWP::UserAgent->new;
 my $vlans = $client->get_vlans( workgroup => 'ajco' );
 
 ok(defined($vlans), "Got a response");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 1, "Expected circuits found!");
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "Expected circuits found!");
 
 
 my $vlan;
@@ -100,7 +100,7 @@ ok(defined($vlan->{'results'}->[0]->{'vlan_id'}), "Got a VLAN ID Back!");
 $vlans = $client->get_vlans( workgroup => 'ajco');
 
 ok(defined($vlans), "Got a valid response");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "We now see that we have a VLAN!");
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 3, "We now see that we have a VLAN!");
 
 my $vlan_details = $client->get_vlan_details( vlan_id => $vlan->{'results'}->[0]->{'vlan_id'},
                                               workgroup => 'ajco');
@@ -205,7 +205,7 @@ ok(defined($new_vlan->{'results'}->[0]->{'vlan_id'}), "Got a VLAN ID Back!");
 $vlans = $client->get_vlans( workgroup => 'ajco');
 
 ok(defined($vlans), "Got a valid response");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 3, "We now see that we have anoterh VLAN!");
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 4, "We now see that we have anoterh VLAN!");
 
 my $edit_vlan2;
 $req = make_request({ method => 'edit_vlan',
@@ -291,4 +291,4 @@ my $edit_vlan4 = $provisioner2->edit_vlan( description => "Automated test suite!
                                            workgroup => 'edco');
 
 ok(defined($edit_vlan4), "Got a valid response");
-ok($edit_vlan4->{'error'}->{'msg'} =~ /Workgroup edco is not allowed to edit vlan/, "Proper error message when unable to provision");
+ok($edit_vlan4->{'error'}->{'msg'} =~ /Workgroup edco not authorized to make this change./, "Proper error message when unable to provision");

--- a/t/202-delete_circuit.t
+++ b/t/202-delete_circuit.t
@@ -83,8 +83,7 @@ my $provisioner = GRNOC::WebService::Client->new( url => 'http://localhost:8529/
 my $vlans = $client->get_vlans( workgroup => 'ajco' );
 
 ok(defined($vlans), "Got a response");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 1, "Expected circuits found!");
-
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "Expected circuits found!");
 
 my $vlan;
 my $req = make_request({ method => 'add_vlan',
@@ -108,7 +107,7 @@ ok(defined($vlan->{'results'}->[0]->{'vlan_id'}), "Got a VLAN ID Back!");
 $vlans = $client->get_vlans( workgroup => 'ajco');
 
 ok(defined($vlans), "Got a valid response");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "We now see that we have a VLAN!");
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 3, "We now see that we have a VLAN!");
 
 my $vlan_details = $client->get_vlan_details( vlan_id => $vlan->{'results'}->[0]->{'vlan_id'},
                                               workgroup => 'ajco');
@@ -157,7 +156,7 @@ ok($delete->{'results'}->[0]->{'success'} == 1, "Successfully delete the circuit
 $vlans = $client->get_vlans( workgroup => 'ajco');
 
 ok(defined($vlans), "Got a valid response");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 1, "Looks like we successfully deleted it");
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "Looks like we successfully deleted it");
 
 $req = make_request({ method => 'add_vlan',
                       description => "Automated test suite!",
@@ -179,7 +178,7 @@ ok(defined($vlan->{'results'}->[0]->{'vlan_id'}), "Got a VLAN ID Back!");
 $vlans = $client->get_vlans( workgroup => 'ajco');
 
 ok(defined($vlans), "Got a valid response");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "We now see that we have a VLAN!");
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 3, "We now see that we have a VLAN!");
 
 $vlan_details = $client->get_vlan_details( vlan_id => $vlan->{'results'}->[0]->{'vlan_id'},
                                            workgroup => 'ajco');
@@ -220,7 +219,7 @@ ok($delete->{'error'}->{'msg'} eq 'User aragusa not in specified workgroup edco'
 $vlans = $client->get_vlans( workgroup => 'ajco');
 
 ok(defined($vlans), "Got a valid response");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "Looks like we did not successfully delete it");
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 3, "Looks like we did not successfully delete it");
 
 my $provisioner2 = GRNOC::WebService::Client->new( url => 'http://localhost:8529/vce/services/provisioning.cgi',
                                                    realm => 'VCE',
@@ -237,7 +236,7 @@ ok($delete->{'error'}->{'msg'} =~ /Workgroup edco is not allowed to edit vlan/, 
 $vlans = $client->get_vlans( workgroup => 'ajco');
 
 ok(defined($vlans), "Got a valid response");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "Looks like we did not successfully delete it");
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 3, "Looks like we did not successfully delete it");
 
 $delete = $provisioner->delete_vlan( vlan_id => '11111',
                                      workgroup => 'ajco');
@@ -247,4 +246,4 @@ ok(!defined($delete->{'results'}->[0]), "Unable to delete the circuit");
 $vlans = $client->get_vlans( workgroup => 'ajco');
 
 ok(defined($vlans), "Got a valid response");
-ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 2, "Looks like we did not successfully delete it");
+ok($#{$vlans->{'results'}->[0]->{'vlans'}} == 3, "Looks like we did not successfully delete it");

--- a/www/frontend/assets/js/edit.js
+++ b/www/frontend/assets/js/edit.js
@@ -34,11 +34,22 @@ function loadVlanDetails() {
             desc.value = circuit.description;
 
             var vlan = document.getElementById('vlan');
+            var set_vlan = false;
             for (var i = 0; i < vlan.options.length; i++) {
                 if (vlan.options[i].value == circuit.vlan) {
                     vlan.selectedIndex = i;
+                    set_vlan = true;
                     break;
                 }
+            }
+
+            if (!set_vlan) {
+                var dropd = document.getElementById("vlan_optgroup");
+                var opt = document.createElement('option');
+                opt.innerHTML = circuit.vlan;
+                opt.setAttribute('value', circuit.vlan);
+                dropd.appendChild(opt);
+                vlan.selectedIndex = vlan.options.length - 1;
             }
 
             // Load and select reported endpoints


### PR DESCRIPTION
Grants port owners the ability to remove any VLAN assigned on their port. The VLAN itself isn't deleted, only modified. Fixes #88.