### PR TITLE
Command permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 vce-*.tar.gz
 Makefile.old
 t/TEST
+MANIFEST.bak
 MYMETA.json
 MYMETA.yml
 Makefile

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ In order to execute some commands, the user must enter into a specific device co
 </command>
 ```
 
+Attribute | Description
+:-------- | :----------
+name | Command name as shown to the user
+context | Network device CLI context that will be entered prior to running the command.
+type | What group the command shall be listed under. Possible values are `show` and `action`.
+user_type | Workgroup permissions required to execute. Possible values are `admin`, `owner`, and `user`.
+
+<command method_name='show_interface' name='show interface' type='show' interaction='cli' description='show all interfaces'>
+
+
 #### Network device credentials
 Setup network device credentials under `<switch>`. **Important:** Each device must expose a port for SSH and allow for netconf connections on port `830`.
 

--- a/etc/config.xsd
+++ b/etc/config.xsd
@@ -48,6 +48,7 @@
     <xs:attribute name="name" type="xs:string" use="required"/>
     <xs:attribute name="type" type="xs:string" use="required"/>
     <xs:attribute name="interaction" type="xs:string" use="required"/>
+    <xs:attribute name="user_type" type="xs:string" use="optional" default="admin"/>
     <xs:attribute name="description" type="xs:string" use="optional"/>
     <xs:attribute name="configure" type="xs:string" use="optional"/>
     <xs:attribute name="context" type="xs:string" use="optional"/>

--- a/lib/VCE.pm
+++ b/lib/VCE.pm
@@ -220,7 +220,6 @@ sub _process_command_config{
 
     foreach my $type ("system","port","vlan"){
         my %commands = %{$config->{$type}->[0]->{'command'}};
-
         foreach my $cmd (keys(%commands)){
             my $val = {
                 name => $cmd,
@@ -231,7 +230,8 @@ sub _process_command_config{
                 configure => $commands{$cmd}{'configure'},
                 params => $commands{$cmd}{'parameter'},
                 description => $commands{$cmd}{'description'},
-                context => $commands{$cmd}{'context'}
+                context => $commands{$cmd}{'context'},
+                user_type => $commands{$cmd}{'user_type'} || 'admin'
             };
             if(!defined($val->{'configure'})){
                 delete $val->{'configure'};

--- a/lib/VCE.pm
+++ b/lib/VCE.pm
@@ -271,8 +271,15 @@ sub get_workgroups{
 
 =head2 get_available_ports
 
-=cut
+    my $ports = get_available_ports(
+      workgroup => 'admin',
+      switch    => '127.0.0.1'
+    );
 
+get_available_ports returns a list of all ports C<workgroup> has
+access to based on the configuration.
+
+=cut
 sub get_available_ports{
     my $self = shift;
     my %params = @_;

--- a/lib/VCE/Access.pm
+++ b/lib/VCE/Access.pm
@@ -506,8 +506,7 @@ sub get_vlan_commands{
         return;
     }
 
-    return $self->config->{'switches'}{$params{'switch'}}->{'commands'}->{'vlan'};    
-
+    return $self->config->{'switches'}{$params{'switch'}}->{'commands'}->{'vlan'};
 }
 
 =head2 get_switch_ports

--- a/lib/VCE/Services/Access.pm
+++ b/lib/VCE/Services/Access.pm
@@ -364,60 +364,59 @@ sub get_port_commands{
     
     my $switch = $p_ref->{'switch'}{'value'};
     
-    if($self->vce->access->user_in_workgroup( username => $user,
-                                              workgroup => $workgroup)){
-        
-        my $ports = $self->vce->get_available_ports( workgroup => $workgroup, switch => $switch);
-        if(scalar($ports) >= 0){
-            my $switch_commands = $self->vce->access->get_port_commands( switch => $switch, port => $ports->[0] );
-            my @results;
-            foreach my $cmd (@$switch_commands){
-                my $obj = {};
-                $obj->{'method_name'} = $cmd->{'method_name'};
-                $obj->{'name'} = $cmd->{'name'};
-                $obj->{'type'} = $cmd->{'type'};
-                $obj->{'parameters'} = ();
-                
-                push(@{$obj->{'parameters'}}, { type => 'hidden',
-                                                name => 'workgroup',
-                                                description => "workgroup to run the command as",
-                                                required => 1 });
-                
-                push(@{$obj->{'parameters'}}, { type => 'hidden',
-                                                name => 'switch',
-                                                description => "switch to run the command on",
-                                                required => 1 });
-                
-                push(@{$obj->{'parameters'}}, { type => 'hidden',
-                                                name => 'port',
-                                                description => "port to run the command on",
-                                                required => 1 });
-                
-                foreach my $param (keys (%{$cmd->{'params'}})){
-                    warn Dumper($cmd->{'params'}{$param});
-                    my $p = {};
-                    
-                    if($cmd->{'params'}{$param}{'type'} eq 'select'){
-                        @{$p->{'options'}} = split(',',$cmd->{'params'}{$param}{'options'});
-                    }else{
-                        
-                    }
-                    $p->{'type'} = $cmd->{'params'}{$param}{'type'};
-                    $p->{'name'} = $param;
-                    $p->{'description'} = $cmd->{'params'}{$param}{'description'};
-                    $p->{'required'} = 1;
-                    push(@{$obj->{'parameters'}}, $p);
-                }
-                
-                push(@results, $obj);
-            }
-            
-            return {results => \@results};
-        }else{
-            return {results => [], error => {msg => "Workgroup not authorized for switch $switch"}};
-        }
-    }else{
+    if (!$self->vce->access->user_in_workgroup(username => $user, workgroup => $workgroup)) {
         return {results => [], error => {msg => "User $user not in specified workgroup $workgroup"}};
+    }
+
+    my $ports = $self->vce->get_available_ports(workgroup => $workgroup, switch => $switch);
+    if(scalar($ports) >= 0){
+        my $switch_commands = $self->vce->access->get_port_commands( switch => $switch, port => $ports->[0] );
+        my @results;
+        foreach my $cmd (@$switch_commands){
+            my $obj = {};
+            $obj->{'method_name'} = $cmd->{'method_name'};
+            $obj->{'name'} = $cmd->{'name'};
+            $obj->{'type'} = $cmd->{'type'};
+            $obj->{'user_type'} = $cmd->{'user_type'};
+            $obj->{'parameters'} = ();
+
+            push(@{$obj->{'parameters'}}, { type => 'hidden',
+                                            name => 'workgroup',
+                                            description => "workgroup to run the command as",
+                                            required => 1 });
+                
+            push(@{$obj->{'parameters'}}, { type => 'hidden',
+                                            name => 'switch',
+                                            description => "switch to run the command on",
+                                            required => 1 });
+                
+            push(@{$obj->{'parameters'}}, { type => 'hidden',
+                                            name => 'port',
+                                            description => "port to run the command on",
+                                            required => 1 });
+                
+            foreach my $param (keys (%{$cmd->{'params'}})){
+                warn Dumper($cmd->{'params'}{$param});
+                my $p = {};
+                    
+                if($cmd->{'params'}{$param}{'type'} eq 'select'){
+                    @{$p->{'options'}} = split(',',$cmd->{'params'}{$param}{'options'});
+                }else{
+                        
+                }
+                $p->{'type'} = $cmd->{'params'}{$param}{'type'};
+                $p->{'name'} = $param;
+                $p->{'description'} = $cmd->{'params'}{$param}{'description'};
+                $p->{'required'} = 1;
+                push(@{$obj->{'parameters'}}, $p);
+            }
+
+            push(@results, $obj);
+        }
+
+        return {results => \@results};
+    }else{
+        return {results => [], error => {msg => "Workgroup not authorized for switch $switch"}};
     }
 }
 

--- a/lib/VCE/Services/Access.pm
+++ b/lib/VCE/Services/Access.pm
@@ -463,8 +463,6 @@ sub get_port_commands{
                 push(@{$results}, $command);
             }
 
-            $self->logger->error(Dumper($results));
-
             return { results => $results };
         }
     }

--- a/www/frontend/assets/js/detail.js
+++ b/www/frontend/assets/js/detail.js
@@ -60,6 +60,14 @@ function loadPorts() {
     var cookie = Cookies.getJSON('vce');
     var name = cookie.switch;
     
+    $('#port_select').change(function(e) {
+        var form = $('#' + e.target.value);
+        form.css("display", "block");
+        form.siblings().css("display", "none");
+
+        document.getElementById('port_form_container').setAttribute('style', 'display: block;');
+    });
+
     var url = baseUrl + 'operational.cgi?method=get_interfaces_operational_status';
     url += '&workgroup=' + cookie.workgroup;
     url += '&switch=' + name;
@@ -98,7 +106,7 @@ function loadPorts() {
                     status.innerHTML = 'Disabled';
                 }
             }
-            
+
             $('#port_table').on('click', '.clickable-row', function(e) {
                 $(this).addClass('active').siblings().removeClass('active');
                 
@@ -138,6 +146,9 @@ function getPortCommands() {
             document.getElementById("port_show_commands").innerHTML = '';
             document.getElementById("port_action_commands").innerHTML = '';
 
+            var formContainer = document.getElementById("port_form_container");
+            formContainer.innerHTML = '';
+
             for (var i = 0; i < cmds.length; i++) {
                 var commandForm = NewCommandForm(cmds[i], function(raw) {
                     var well = document.getElementById("port_response_well");
@@ -147,8 +158,6 @@ function getPortCommands() {
                     pre.innerHTML = raw;
                     well.appendChild(pre);
                 });
-
-                var formContainer = document.getElementById("port_form_container");
                 formContainer.appendChild(commandForm);
 
                 var opt = document.createElement('option');
@@ -292,6 +301,9 @@ function getVlanCommands() {
             // Remove commands from dropdown for command population
             document.getElementById("vlan_show_commands").innerHTML = '';
 
+            var formContainer = document.getElementById("vlan_form_container");
+            formContainer.innerHTML = '';
+
             for (var i = 0; i < cmds.length; i++) {
                 var commandForm = NewCommandForm(cmds[i], function(raw) {
                     var well = document.getElementById("vlan_response_well");
@@ -301,8 +313,6 @@ function getVlanCommands() {
                     pre.innerHTML = raw;
                     well.appendChild(pre);
                 });
-                
-                var formContainer = document.getElementById("vlan_form_container");
                 formContainer.appendChild(commandForm);
                 
                 var opt = document.createElement('option');

--- a/www/frontend/assets/js/detail.js
+++ b/www/frontend/assets/js/detail.js
@@ -319,56 +319,6 @@ function getVlanCommands() {
     });
 }
 
-
-function loadPortCommands() {
-    var cookie = Cookies.getJSON('vce');
-    
-    $('#port_select').change(function(e) {
-        var form = $('#' + e.target.value);
-        form.css("display", "block");
-        form.siblings().css("display", "none");
-
-        document.getElementById('port_form_container').setAttribute('style', 'display: block;');
-    });
-    
-    var url = baseUrl + 'access.cgi?method=get_port_commands';
-    url += '&workgroup=' + cookie.workgroup;
-    url += '&switch=' + cookie.switch;
-    fetch(url, {method: 'get', credentials: 'include'}).then(function(response) {
-        response.json().then(function(data) {
-            if (typeof data.error !== 'undefined') {
-                return displayError(data.error.msg);
-            }
-
-            var cmds = data.results;
-            
-            for (var i = 0; i < cmds.length; i++) {
-                var commandForm = NewCommandForm(cmds[i], function(raw) {
-                    var well = document.getElementById("port_response_well");
-                    well.innerHTML = "";
-
-                    var pre = document.createElement("pre");
-                    pre.innerHTML = raw;
-                    well.appendChild(pre);
-                });
-                
-                var formContainer = document.getElementById("port_form_container");
-                formContainer.appendChild(commandForm);
-                
-                var opt = document.createElement('option');
-                opt.innerHTML = cmds[i].name;
-                opt.setAttribute('value', cmds[i].method_name);
-                
-                if (cmds[i].type == "show") {
-                    document.getElementById("port_show_commands").appendChild(opt);
-                } else {
-                    document.getElementById("port_action_commands").appendChild(opt);
-                }
-            }
-        });
-    });
-}
-
 function loadSwitchCommands() {
     var cookie = Cookies.getJSON('vce');
     

--- a/www/frontend/assets/js/zrouter.js
+++ b/www/frontend/assets/js/zrouter.js
@@ -98,7 +98,6 @@ window.onload = function() {
         loadVlans();
         loadSwitch();
         
-        loadPortCommands();
         loadSwitchCommands();
         
         setInterval(loadPorts, 30000);

--- a/www/frontend/assets/js/zrouter.js
+++ b/www/frontend/assets/js/zrouter.js
@@ -100,7 +100,6 @@ window.onload = function() {
         
         loadPortCommands();
         loadSwitchCommands();
-        loadVlanCommands();
         
         setInterval(loadPorts, 30000);
         setInterval(loadVlans, 30000);


### PR DESCRIPTION
This change introduces command permissions via the `user_type` attribute on the XML command tags. This is an optional attribute that defaults to `admin` when not provided. This attribute restricts the set of commands available to each user. All commands may be run by users of the admin workgroup regardless of the `user_type`.

- admin: The admin role restricts commands to the admin workgroup only.
- owner: The owner role restricts the set of commands to the workgroup who owns the relevant port or vlan. For example: A non-admin workgroup may be able to see a port on the frontend but unless it's the port's owner, it will only have the right to run commands with `user_type=user`.
- user: The user role allows all workgroups to execute the command.

fixes #113 and fixes #114 