### PR TITLE
Adding check for pre-existing workgroup in web cookie

### DIFF
--- a/www/frontend/assets/js/workgroup.js
+++ b/www/frontend/assets/js/workgroup.js
@@ -13,27 +13,35 @@ function selectWorkgroup(e) {
 // Get all workgroups for this user. If the workgroup has not yet been set,
 // use the first found.
 function loadWorkgroups() {
-    var workgroupName;
-    
-    cookie = Cookies.getJSON('vce');
-    if (cookie != undefined) {
-        workgroupName = cookie.workgroup;
-    }
-    
     var url = baseUrl + 'access.cgi?method=get_workgroups';
-    fetch(url, {method: 'get', credentials: 'include'}).then(function(response) {
-        response.json().then(function(data) {
+    return fetch(url, {method: 'get', credentials: 'include'}).then(function(response) {
+        return response.json().then(function(data) {
             if (typeof data.error !== 'undefined') {
                 return displayError(data.error.msg);
             }
 
+            var cookie = Cookies.getJSON('vce');
+            var workgroup = cookie.workgroup;
+
             var workgroups = data.results[0].workgroups;
-            
-            var selectedWorkgroup = document.getElementById('workgroup_select');
-            if (workgroupName === null) {
-                workgroupName = workgroups[0];
+            if (workgroup === null) {
+                    workgroup = workgroups[0];
+            } else {
+                var workgroupFound = false;
+
+                for (var i = 0; i < workgroups.length; i++) {
+                    if (workgroups[i] === workgroup) {
+                        workgroupFound = true;
+                    }
+                }
+
+                if (!workgroupFound) {
+                    workgroup = workgroups[0];
+                }
             }
-            selectedWorkgroup.innerHTML = workgroupName + ' ▾';
+
+            var selectedWorkgroup = document.getElementById('workgroup_select');
+            selectedWorkgroup.innerHTML = workgroup + ' ▾';
             
             var workgroupList = document.getElementById('workgroup_select_list');
             workgroupList.innerHTML = '';
@@ -50,8 +58,10 @@ function loadWorkgroups() {
                 workgroupList.appendChild(li);
             }
             
-            cookie.workgroup = workgroupName;
+            cookie.workgroup = workgroup;
             Cookies.set('vce', cookie);
+
+            return Cookies.getJSON('vce');
         });
     });
 }

--- a/www/frontend/assets/js/zrouter.js
+++ b/www/frontend/assets/js/zrouter.js
@@ -1,9 +1,9 @@
 function loadCookie() {
     cookie = Cookies.getJSON('vce');
     if (cookie === undefined) {
-        console.log('setting cookie');
         Cookies.set('vce', {workgroup: 'admin', switches: ['switch']});
     }
+
     /*
     {
         workgroup:      'ajco' // Name of the currently active workgroup
@@ -12,6 +12,8 @@ function loadCookie() {
         selectedVlanId: ''     // Currently selected VLAN ID
     }
     */
+
+    return loadWorkgroups();
 }
 
 function setDisplayMessage(type, text) {
@@ -83,43 +85,40 @@ function displaySuccess(success) {
 // The var $allow_credentials in Method.pm must be set to 'true'
 // for cors.
 window.onload = function() {
-    loadErrorCloseButton();
-    loadCookie();
-    cookie = Cookies.getJSON('vce');
+    loadCookie().then(function(cookie) {
+        loadErrorCloseButton();
 
-    setHeader(cookie.switches);
+        setHeader(cookie.switches);
 
-    var url = window.location;
-    if (url.pathname.indexOf('details.html') > -1) {
-        loadSuccessCloseButton();
-        selectTab();
+        var url = window.location;
+        if (url.pathname.indexOf('details.html') > -1) {
+            loadSuccessCloseButton();
+            selectTab();
 
-        loadPorts();
-        loadVlans();
-        loadSwitch();
+            loadPorts();
+            loadVlans();
+            loadSwitch();
         
-        loadSwitchCommands();
+            loadSwitchCommands();
         
-        setInterval(loadPorts, 30000);
-        setInterval(loadVlans, 30000);
-    } else if (url.pathname.indexOf('create.html') > -1) {
-        loadVlanDropdown();
-        configureButtons();
-    } else if (url.pathname.indexOf('edit.html') > -1) {
-        loadVlanDropdown()
-        .then(
-            loadVlanDetails
-        );
-        configureEditButtons();
-    } else {
-        // Must be run first
-        loadWorkgroups();
+            setInterval(loadPorts, 30000);
+            setInterval(loadVlans, 30000);
+        } else if (url.pathname.indexOf('create.html') > -1) {
+            loadVlanDropdown();
+            configureButtons();
+        } else if (url.pathname.indexOf('edit.html') > -1) {
+            loadVlanDropdown()
+                .then(
+                    loadVlanDetails
+                );
+            configureEditButtons();
+        } else {
+            loadSwitches();
+            loadWorkgroup();
         
-        loadSwitches();
-        loadWorkgroup();
-        
-        setInterval(loadSwitches, 15000);
-    }
+            setInterval(loadSwitches, 15000);
+        }
 
-    showDisplayMessage();
+        showDisplayMessage();
+    });
 }


### PR DESCRIPTION
Between logins, the workgroup stored in the vce cookie may
persist. This change verifies the selected workgroup is valid for the
current user, if not the workgroup is changed to the first one
available. Fixes #140.