### PR TITLE
updating xsd for access_policy validation

### DIFF
--- a/etc/config.xsd
+++ b/etc/config.xsd
@@ -114,7 +114,7 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element name="rabbit" type="rabbit" minOccurs="1" maxOccurs="1"/>
-        <xs:element name="network_model" type="network_model" minOccurs="1" maxOccurs="1"/>
+        <xs:element name="network_model" type="network_model" minOccurs="0" maxOccurs="1"/>
         <xs:element name="switch" type="switch" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element name="workgroup" type="workgroup" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>

--- a/etc/config.xsd
+++ b/etc/config.xsd
@@ -113,10 +113,10 @@
   <xs:element name="accessPolicy">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="rabbit" type="rabbit"/>
-        <xs:element name="network_model" type="network_model" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="rabbit" type="rabbit" minOccurs="1" maxOccurs="1"/>
+        <xs:element name="network_model" type="network_model" minOccurs="1" maxOccurs="1"/>
         <xs:element name="switch" type="switch" minOccurs="0" maxOccurs="unbounded"/>
-        <xs:element name="workgroup" type="workgroup" minOccurs="1" maxOccurs="unbounded"/>
+        <xs:element name="workgroup" type="workgroup" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
This change ensures that rabbitmq and the database location are
configured and allows for the rest of the config to be deleted (if
desired).

Fixes #235