### PR TITLE
Adding logic to issue_command to handle cli write commands

### DIFF
--- a/lib/VCE/Device/Brocade/MLXe/5_8_0.pm
+++ b/lib/VCE/Device/Brocade/MLXe/5_8_0.pm
@@ -420,40 +420,10 @@ sub vlan_spanning_tree {
     my $res;
     my $err;
 
-    my $ok = $self->configure();
-    if (!$ok) {
-        $err = "Could not enter configure mode.";
-        $self->logger->error($err);
-        return $res, $err;
-    }
-
-    $ok = $self->set_context("vlan $vlan_id");
-    if (!$ok) {
-        $err = "Could not enter vlan configure mode.";
-        $self->logger->error($err);
-        return $res, $err;
-    }
-
-    ($res, $err) = $self->issue_command("spanning-tree", "#");
+    ($res, $err) = $self->issue_command("conf t; vlan $vlan_id; spanning-tree", "#", "write");
     if ($err) {
         $self->logger->error($err);
         return $res, $err;
-    }
-
-    ($res, $err) = $self->issue_command("write mem", "#");
-    if ($err) {
-        $self->logger->error($err);
-        return $res, $err;
-    }
-
-    $ok = $self->exit_context();
-    if (!$ok) {
-        $self->logger->warn("Failed to exit context.");
-    }
-
-    $ok = $self->exit_configure();
-    if (!$ok) {
-        $self->logger->warn("Failed to exit configure.");
     }
 
     return $res, $err;
@@ -474,40 +444,10 @@ sub no_vlan_spanning_tree {
     my $res;
     my $err;
 
-    my $ok = $self->configure();
-    if (!$ok) {
-        $err = "Could not enter configure mode.";
-        $self->logger->error($err);
-        return $res, $err;
-    }
-
-    $ok = $self->set_context("vlan $vlan_id");
-    if (!$ok) {
-        $err = "Could not enter vlan configure mode.";
-        $self->logger->error($err);
-        return $res, $err;
-    }
-
-    ($res, $err) = $self->issue_command("no spanning-tree", "#");
+    ($res, $err) = $self->issue_command("conf t; vlan $vlan_id; no spanning-tree", "#", "write");
     if ($err) {
         $self->logger->error($err);
         return $res, $err;
-    }
-
-    ($res, $err) = $self->issue_command("write mem", "#");
-    if ($err) {
-        $self->logger->error($err);
-        return $res, $err;
-    }
-
-    $ok = $self->exit_context();
-    if (!$ok) {
-        $self->logger->warn("Failed to exit context.");
-    }
-
-    $ok = $self->exit_configure();
-    if (!$ok) {
-        $self->logger->warn("Failed to exit configure.");
     }
 
     return $res, $err;
@@ -957,6 +897,7 @@ sub issue_command{
     my $self    = shift;
     my $command = shift;
     my $prompt  = shift;
+    my $operation = shift || 'read';
 
     my $statements_run = 0;
     my @statements = split(/;\s*/, $command);
@@ -978,6 +919,15 @@ sub issue_command{
         }
 
         $statements_run += 1;
+    }
+
+    if ($operation eq 'write') {
+        $self->logger->info("Running command: write mem");
+        my $ok = $self->comm->issue_command('write mem', $prompt);
+        if (!defined $ok) {
+            $self->logger->error("Couldn't run 'write mem'.");
+        }
+        $result = '';
     }
 
     # Consider running C<conf t>, C<vlan 218>, C<spanning-tree>. To

--- a/lib/VCE/Device/JUNOS/MX/17.pm
+++ b/lib/VCE/Device/JUNOS/MX/17.pm
@@ -661,6 +661,7 @@ sub issue_command{
     my $self    = shift;
     my $command = shift;
     my $prompt  = shift;
+    my $operation = shift || 'read';
 
     my $statements_run = 0;
     my @statements = split(/;\s*/, $command);
@@ -682,6 +683,15 @@ sub issue_command{
         }
 
         $statements_run += 1;
+    }
+
+    if ($operation eq 'write') {
+        $self->logger->info("Running command: commit");
+        my $ok = $self->comm->issue_command('commit', $prompt);
+        if (!defined $ok) {
+            $self->logger->error("Couldn't run 'commit'.");
+        }
+        $result = '';
     }
 
     # Consider running C<conf t>, C<vlan 218>, C<spanning-tree>. To

--- a/lib/VCE/Switch.pm
+++ b/lib/VCE/Switch.pm
@@ -873,12 +873,12 @@ sub execute_command{
     my $err;
 
     if ($self->vendor eq 'Brocade') {
-        ($result, $err) = $self->device->issue_command($p_ref->{'command'}{'value'}, qr/\n.*\#$/);
+        ($result, $err) = $self->device->issue_command($p_ref->{'command'}{'value'}, qr/\n.*\#$/, $p_ref->{'cli_type'}{'value'});
         if (defined $err) {
             return &$success({success => 0, error => 1, error_msg => $err});
         }
     } else {
-        ($result, $err) = $self->device->issue_command($p_ref->{'command'}{'value'}, qr/\n.*\> $/);
+        ($result, $err) = $self->device->issue_command($p_ref->{'command'}{'value'}, qr/\n.*(\> |\# )$/, $p_ref->{'cli_type'}{'value'});
         if (defined $err) {
             return &$success({success => 0, error => 1, error_msg => $err});
         }


### PR DESCRIPTION
The last step in running a write command is to commit the config
changes via 'write mem'. When we last updated the issue_command method
to handle templated commands, we failed to handle this case which led
to uncommitted changes being added to the device. This also had the
effect of triggering a device error between cli command executions
`Cannot undo the configuration as ... session is using this mode`.

This change passes the command type '(read|write)' to issue_command
and issues 'write mem' before exiting the cli context switches.